### PR TITLE
Update Level1.unity

### DIFF
--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -19793,7 +19793,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 10
   jumpPower: 15
-  extraJumps: 1
+  extraJumps: 2
   groundLayer:
     serializedVersion: 2
     m_Bits: 512


### PR DESCRIPTION
Changed extraJumps to 2 because in the latest version of the game the dash does not work. Whith 2 extaJymps it is possible to win the game.